### PR TITLE
Changed name input type

### DIFF
--- a/opencart 1.5.6.4/upload/catalog/view/theme/default/template/module/smaily_for_opencart.tpl
+++ b/opencart 1.5.6.4/upload/catalog/view/theme/default/template/module/smaily_for_opencart.tpl
@@ -20,7 +20,7 @@
         </div>
         <div class="from-group">
           <div class="input-group">
-            <input type="text" class="form-control" name="name" placeholder="<?php echo $optin_form_name_placeholder; ?>" />
+            <input type="name" class="form-control" name="name" placeholder="<?php echo $optin_form_name_placeholder; ?>" />
             <span class="input-group-btn">
               <button type="submit" class="btn btn-sm btn-primary"><?php echo $optin_form_subscribe_button; ?></button>
             </span>


### PR DESCRIPTION
Optin form's name input didn't have the same style as email input.
Changed the input type from 'text to 'name' so it looks like the same now.