### PR TITLE
Fixed not displaying full site URL for CRON links.

### DIFF
--- a/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -120,7 +120,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
         $data['sync_token_title'] = $this->language->get('sync_token_title');
         $data['sync_token_placeholder'] = $this->language->get('sync_token_placeholder');
         $data['sync_customer_url_title'] = $this->language->get('sync_customer_url_title');
-        $data['customer_cron_url'] = $this->config->get('config_url') . 'index.php?route=extension/smailyforopencart/cron_customers&token=[token]';
+        $data['customer_cron_url'] = str_replace('/admin','',$this->config->get('site_url')) . 'index.php?route=extension/smailyforopencart/cron_customers&token=[token]';
         $data['customer_cron_text'] = $this->language->get('customer_cron_text');
         // Customer sync option fields text.
         $data['firstname'] = $this->language->get('firstname');
@@ -135,7 +135,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
         $data['cart_token_title'] = $this->language->get('cart_token_title');
         $data['cart_token_placeholder'] = $this->language->get('cart_token_placeholder');
         $data['sync_cart_url_title'] = $this->language->get('sync_cart_url_title');
-        $data['cart_cron_url'] = $this->config->get('config_url') . 'index.php?route=extension/smailyforopencart/cron_cart&token=[token]';
+        $data['cart_cron_url'] = str_replace('/admin','',$this->config->get('site_url')) . 'index.php?route=extension/smailyforopencart/cron_cart&token=[token]';
         $data['cart_cron_text'] = $this->language->get('cart_cron_text');
         // Abandoned cart option fields text.
         $data['product_name'] = $this->language->get('product_name');
@@ -145,7 +145,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
 
         // Small texts.
         $data['small_subdomain'] = $this->language->get('small_subdomain');
-        $data['smaily_rss_url'] = $this->config->get('config_url') . 'index.php?route=extension/smailyforopencart/rss';
+        $data['smaily_rss_url'] = str_replace('/admin','',$this->config->get('site_url')) . 'index.php?route=extension/smailyforopencart/rss';
         $data['small_password'] = $this->language->get('small_password');
         $data['small_sync_additional'] = $this->language->get('small_sync_additional');
         $data['small_cart_additional'] = $this->language->get('small_cart_additional');
@@ -372,7 +372,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
             $response = [];
             // Language for resonse.
             $this->load->language('extension/module/smaily_for_opencart');
-            
+
             // Check if all fields are set.
             if (empty($this->request->post['subdomain']) ||
                 empty($this->request->post['username']) ||
@@ -396,7 +396,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
                 $subdomain = $parts[0];
             }
             $subdomain = preg_replace('/[^a-zA-Z0-9]+/', '', $subdomain);
-            
+
             $subdomain = $this->db->escape($subdomain);
             $username =  $this->db->escape($this->request->post['username']);
             $password = $this->db->escape($this->request->post['password']);

--- a/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -86,7 +86,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
             ),
         );
         // Get URL for CRON links.
-        $url = new Url(HTTPS_CATALOG, $this->config->get('config_secure') ? HTTPS_CATALOG : HTTP_CATALOG);
+        $url = defined(HTTPS_CATALOG) ? new Url(HTTPS_CATALOG, $this->config->get('config_secure')) : new Url(HTTP_CATALOG);
         // Initalize customer sync token.
         if (! empty($this->request->post['module_smaily_for_opencart_sync_token'])) {
             // Get sync token if user adds custom one.

--- a/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -86,9 +86,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
             ),
         );
         // Get URL for CRON links.
-        $url = new Url(HTTP_CATALOG, $this->config->get('config_secure') ? HTTP_CATALOG : HTTPS_CATALOG);
-        $url->link('extension/smailyforopencart/cron_customers');
-
+        $url = new Url(HTTPS_CATALOG, $this->config->get('config_secure') ? HTTPS_CATALOG : HTTP_CATALOG);
         // Initalize customer sync token.
         if (! empty($this->request->post['module_smaily_for_opencart_sync_token'])) {
             // Get sync token if user adds custom one.
@@ -146,7 +144,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
         $data['sync_token_title'] = $this->language->get('sync_token_title');
         $data['sync_token_placeholder'] = $this->language->get('sync_token_placeholder');
         $data['sync_customer_url_title'] = $this->language->get('sync_customer_url_title');
-        $data['customer_cron_url'] = $url->link('extension/smailyforopencart/cron_customers') . "&token=" . $data['sync_token'];
+        $data['customer_cron_url'] = $url->link('extension/smailyforopencart/cron_customers', array('token' => $data['sync_token']), true);
         $data['customer_cron_text'] = $this->language->get('customer_cron_text');
         // Customer sync option fields text.
         $data['firstname'] = $this->language->get('firstname');
@@ -161,7 +159,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
         $data['cart_token_title'] = $this->language->get('cart_token_title');
         $data['cart_token_placeholder'] = $this->language->get('cart_token_placeholder');
         $data['sync_cart_url_title'] = $this->language->get('sync_cart_url_title');
-        $data['cart_cron_url'] = $url->link('extension/smailyforopencart/cron_cart') . "&token=" . $data['cart_token'];
+        $data['cart_cron_url'] = $url->link('extension/smailyforopencart/cron_cart', array('token' => $data['cart_token']), true);
         $data['cart_cron_text'] = $this->language->get('cart_cron_text');
         // Abandoned cart option fields text.
         $data['product_name'] = $this->language->get('product_name');
@@ -171,7 +169,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
 
         // Small texts.
         $data['small_subdomain'] = $this->language->get('small_subdomain');
-        $data['smaily_rss_url'] = $url->link('extension/smailyforopencart/rss');
+        $data['smaily_rss_url'] = $url->link('extension/smailyforopencart/rss', '', true);
         $data['small_password'] = $this->language->get('small_password');
         $data['small_sync_additional'] = $this->language->get('small_sync_additional');
         $data['small_cart_additional'] = $this->language->get('small_cart_additional');

--- a/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -85,7 +85,33 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
                 'name' => $this->language->get('section_abandoned'),
             ),
         );
+        // Get URL for CRON links.
+        $url = new Url(HTTP_CATALOG, $this->config->get('config_secure') ? HTTP_CATALOG : HTTPS_CATALOG);
+        $url->link('extension/smailyforopencart/cron_customers');
 
+        // Initalize customer sync token.
+        if (! empty($this->request->post['module_smaily_for_opencart_sync_token'])) {
+            // Get sync token if user adds custom one.
+            $data['sync_token'] = $this->request->post['module_smaily_for_opencart_sync_token'];
+        } else {
+            if (! empty($this->config->get('module_smaily_for_opencart_sync_token'))) {
+                $data['sync_token'] = $this->config->get('module_smaily_for_opencart_sync_token');
+            } else {
+                // Generate random token if not saved in db.
+                $data['sync_token'] = uniqid();
+            }
+        }
+        // Initalize abandoned cart token.
+        if (! empty($this->request->post['module_smaily_for_opencart_cart_token'])) {
+            $data['cart_token'] = $this->request->post['module_smaily_for_opencart_cart_token'];
+        } else {
+            if (! empty($this->config->get('module_smaily_for_opencart_cart_token'))) {
+                $data['cart_token'] = $this->config->get('module_smaily_for_opencart_cart_token');
+            } else {
+                // Generate random token if not saved in db.
+                $data['cart_token'] = uniqid();
+            }
+        }
         // Text fields
         $data['heading_title'] = $this->language->get('heading_title');
         $data['text_edit'] = $this->language->get('text_edit');
@@ -120,7 +146,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
         $data['sync_token_title'] = $this->language->get('sync_token_title');
         $data['sync_token_placeholder'] = $this->language->get('sync_token_placeholder');
         $data['sync_customer_url_title'] = $this->language->get('sync_customer_url_title');
-        $data['customer_cron_url'] = str_replace('/admin','',$this->config->get('site_url')) . 'index.php?route=extension/smailyforopencart/cron_customers&token=[token]';
+        $data['customer_cron_url'] = $url->link('extension/smailyforopencart/cron_customers') . "&token=" . $data['sync_token'];
         $data['customer_cron_text'] = $this->language->get('customer_cron_text');
         // Customer sync option fields text.
         $data['firstname'] = $this->language->get('firstname');
@@ -135,7 +161,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
         $data['cart_token_title'] = $this->language->get('cart_token_title');
         $data['cart_token_placeholder'] = $this->language->get('cart_token_placeholder');
         $data['sync_cart_url_title'] = $this->language->get('sync_cart_url_title');
-        $data['cart_cron_url'] = str_replace('/admin','',$this->config->get('site_url')) . 'index.php?route=extension/smailyforopencart/cron_cart&token=[token]';
+        $data['cart_cron_url'] = $url->link('extension/smailyforopencart/cron_cart') . "&token=" . $data['cart_token'];
         $data['cart_cron_text'] = $this->language->get('cart_cron_text');
         // Abandoned cart option fields text.
         $data['product_name'] = $this->language->get('product_name');
@@ -145,7 +171,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
 
         // Small texts.
         $data['small_subdomain'] = $this->language->get('small_subdomain');
-        $data['smaily_rss_url'] = str_replace('/admin','',$this->config->get('site_url')) . 'index.php?route=extension/smailyforopencart/rss';
+        $data['smaily_rss_url'] = $url->link('extension/smailyforopencart/rss');
         $data['small_password'] = $this->language->get('small_password');
         $data['small_sync_additional'] = $this->language->get('small_sync_additional');
         $data['small_cart_additional'] = $this->language->get('small_cart_additional');
@@ -272,18 +298,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
         } else {
             $data['syncronize_additional'] = $this->config->get('module_smaily_for_opencart_syncronize_additional') ? $this->config->get('module_smaily_for_opencart_syncronize_additional') : [];
         }
-        // Customer sync token.
-        if (! empty($this->request->post['module_smaily_for_opencart_sync_token'])) {
-            // Get sync token if user adds custom one.
-            $data['sync_token'] = $this->request->post['module_smaily_for_opencart_sync_token'];
-        } else {
-            if (! empty($this->config->get('module_smaily_for_opencart_sync_token'))) {
-                $data['sync_token'] = $this->config->get('module_smaily_for_opencart_sync_token');
-            } else {
-                // Generate random token if not saved in db.
-                $data['sync_token'] = uniqid();
-            }
-        }
+
         // Abandoned cart autoresponder.
         if (isset($this->request->post['module_smaily_for_opencart_abandoned_autoresponder'])) {
             $data['abandoned_autoresponder'] = json_decode(html_entity_decode($this->request->post['module_smaily_for_opencart_abandoned_autoresponder']), true);
@@ -302,17 +317,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
         } else {
             $data['cart_delay'] = $this->config->get('module_smaily_for_opencart_cart_delay');
         }
-        // Abandoned cart token.
-        if (! empty($this->request->post['module_smaily_for_opencart_cart_token'])) {
-            $data['cart_token'] = $this->request->post['module_smaily_for_opencart_cart_token'];
-        } else {
-            if (! empty($this->config->get('module_smaily_for_opencart_cart_token'))) {
-                $data['cart_token'] = $this->config->get('module_smaily_for_opencart_cart_token');
-            } else {
-                // Generate random token if not saved in db.
-                $data['cart_token'] = uniqid();
-            }
-        }
+
 
 
         $data['header'] = $this->load->controller('common/header');

--- a/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -86,7 +86,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
             ),
         );
         // Get URL for CRON links.
-        $url = defined($this->config->get('config_secure')) ? new Url(HTTP_CATALOG, $this->config->get('config_secure')) : new Url(HTTP_CATALOG);
+        $url = new Url(HTTP_CATALOG, $this->config->get('config_secure') ? HTTPS_CATALOG : '');
         // Initalize customer sync token.
         if (! empty($this->request->post['module_smaily_for_opencart_sync_token'])) {
             // Get sync token if user adds custom one.

--- a/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/opencart 3.0.0.0 - 3.0.3.1/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -86,7 +86,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
             ),
         );
         // Get URL for CRON links.
-        $url = defined(HTTPS_CATALOG) ? new Url(HTTPS_CATALOG, $this->config->get('config_secure')) : new Url(HTTP_CATALOG);
+        $url = defined($this->config->get('config_secure')) ? new Url(HTTP_CATALOG, $this->config->get('config_secure')) : new Url(HTTP_CATALOG);
         // Initalize customer sync token.
         if (! empty($this->request->post['module_smaily_for_opencart_sync_token'])) {
             // Get sync token if user adds custom one.

--- a/opencart 3.0.0.0 - 3.0.3.1/upload/admin/language/en-gb/extension/module/smaily_for_opencart.php
+++ b/opencart 3.0.0.0 - 3.0.3.1/upload/admin/language/en-gb/extension/module/smaily_for_opencart.php
@@ -41,7 +41,7 @@ $_['rss_feed_text']                    = "Copy this URL into your template edito
 $_['entry_customer_sync_fields_title'] = 'Customer Synchronization fields';
 $_['sync_token_title']                 = 'Customer Cron Token*';
 $_['sync_customer_url_title']          = 'Cron url';
-$_['customer_cron_text']               = 'Use this url to run cron. Token must be provided';
+$_['customer_cron_text']               = 'Use this url to run cron.';
 // Abandoned cart form
 $_['entry_autoresponder_title']        = 'Autoresponder ID*';
 $_['abandoned_sync_fields_title']      = 'Abandoned Cart additional fields';
@@ -49,7 +49,7 @@ $_['delay_title']                      = 'Abandoned cart delay time';
 $_['abandoned_minutes']                = 'minutes';
 $_['cart_token_title']                 = 'Abandoned Cart Token*';
 $_['sync_cart_url_title']              = 'Abandoned Cart Url';
-$_['cart_cron_text']                   = 'Use this url to run cron. Token must be provided';
+$_['cart_cron_text']                   = 'Use this url to run cron.';
 
 //Placeholders
 $_['placeholder_subdomain']  = 'Please enter subdomain';


### PR DESCRIPTION
Changed way website URL is retrieved from config.
On a fresh opencart install, the config_url would return null
Now it retrieves the admin page URL and removes /admin/ from it.