### PR TITLE
Save customer sync cron time before finished

### DIFF
--- a/opencart 2.2.0.0/upload/catalog/controller/smailyforopencart/cron_customers.php
+++ b/opencart 2.2.0.0/upload/catalog/controller/smailyforopencart/cron_customers.php
@@ -49,6 +49,7 @@ class ControllerSmailyForOpencartCronCustomers extends Controller {
             $response = 'No customers to sync in OpenCart database';
             $offset_sub = 0;
             $last_sync = $this->model_smailyforopencart_helper->getSyncTime();
+            $sync_time = date('c');
             while (true) {
                 $subscribers = $this->model_smailyforopencart_helper->getSubscribedCustomers($offset_sub, $last_sync);
                 if (empty($subscribers)) {
@@ -73,7 +74,11 @@ class ControllerSmailyForOpencartCronCustomers extends Controller {
                     die('Error with request to Smaily API, try again later.');
                 }
             }
-            $this->model_smailyforopencart_helper->editSettingValue('smaily_for_opencart', 'smaily_for_opencart_sync_time', date('c'));
+            $this->model_smailyforopencart_helper->editSettingValue(
+                'smaily_for_opencart',
+                'smaily_for_opencart_sync_time',
+                $sync_time,
+            );
 
             $this->log->write('smaily subscriber sync finished: ' . json_encode($response));
             echo 'Smaily subscriber sync finished.';

--- a/opencart 2.3.0.0 - 2.3.0.2/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
+++ b/opencart 2.3.0.0 - 2.3.0.2/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
@@ -49,6 +49,7 @@ class ControllerExtensionSmailyForOpencartCronCustomers extends Controller {
             $response = 'No customers to sync in OpenCart database';
             $offset_sub = 0;
             $last_sync = $this->model_extension_smailyforopencart_helper->getSyncTime();
+            $sync_time = date('c');
             while (true) {
                 $subscribers = $this->model_smailyforopencart_helper->getSubscribedCustomers($offset_sub, $last_sync);
                 if (empty($subscribers)) {
@@ -73,7 +74,11 @@ class ControllerExtensionSmailyForOpencartCronCustomers extends Controller {
                     die('Error with request to Smaily API, try again later.');
                 }
             }
-            $this->model_extension_smailyforopencart_helper->editSettingValue('smaily_for_opencart', 'smaily_for_opencart_sync_time', date('c'));
+            $this->model_extension_smailyforopencart_helper->editSettingValue(
+                'smaily_for_opencart',
+                'smaily_for_opencart_sync_time',
+                $sync_time,
+            );
 
             $this->log->write('smaily subscriber sync finished: ' . json_encode($response));
             echo 'Smaily subscriber sync finished.';

--- a/opencart 3.0.0.0 - 3.0.3.1/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
+++ b/opencart 3.0.0.0 - 3.0.3.1/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
@@ -49,6 +49,7 @@ class ControllerExtensionSmailyForOpencartCronCustomers extends Controller {
             $response = 'No customers to sync in OpenCart database';
             $offset_sub = 0;
             $last_sync = $this->model_extension_smailyforopencart_helper->getSyncTime();
+            $sync_time = date('c');
             while (true) {
                 $subscribers = $this->model_extension_smailyforopencart_helper->getSubscribedCustomers($offset_sub, $last_sync);
                 if (empty($subscribers)) {
@@ -73,7 +74,11 @@ class ControllerExtensionSmailyForOpencartCronCustomers extends Controller {
                     die('Error with request to Smaily API, try again later.');
                 }
             }
-            $this->model_extension_smailyforopencart_helper->editSettingValue('module_smaily_for_opencart', 'module_smaily_for_opencart_sync_time', date('c'));
+            $this->model_extension_smailyforopencart_helper->editSettingValue(
+                'module_smaily_for_opencart',
+                'module_smaily_for_opencart_sync_time',
+                $sync_time,
+            );
 
             $this->log->write('smaily subscriber sync finished: ' . json_encode($response));
             echo 'Smaily subscriber sync finished.';


### PR DESCRIPTION
Previously customer sync time was saved when cron was finished.
This could cause issues when cron takes a long time and some customers are added/modified in the meantime.
Currently, it will get a pointer with the time before starting cron and save that time to settings after cron finishes.