### PR TITLE
Make Docker's OpenCart installation more user friendly

### DIFF
--- a/opencart 1.5.6.4/Dockerfile
+++ b/opencart 1.5.6.4/Dockerfile
@@ -24,10 +24,12 @@ RUN curl -L https://github.com/opencart/opencart/archive/$OPENCART_VERSION.tar.g
     && mv opencart-$OPENCART_VERSION/upload/* . \
     && rm -rf opencart.tar.gz opencart-$OPENCART_VERSION/
 
-# Prefill mySQL credentials
+# Prefill mySQL credentials & OpenCart password and email.
 RUN sed -i -e "s/\['db_name'] = ''/['db_name'] = 'opencart'/g" install/controller/step_3.php \
     && sed -i -e "s/\['db_user'] = ''/['db_user'] = 'root'/g" install/controller/step_3.php \
-    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'examplepass'/g" install/controller/step_3.php \
+    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'smaily1'/g" install/controller/step_3.php \
+    && sed -i -e "s/\['password'] = ''/['password'] = 'smaily1'/g" install/controller/step_3.php \
+    && sed -i -e "s/\['email'] = ''/['email'] = 'testing@smaily.sb'/g" install/controller/step_3.php \
     && sed -i "s/localhost/database/g" install/controller/step_3.php
 
 # Add Smaily plugin files to /html

--- a/opencart 1.5.6.4/docker-compose.yml
+++ b/opencart 1.5.6.4/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: always
     environment:
       MYSQL_DATABASE: opencart
-      MYSQL_ROOT_PASSWORD: examplepass
+      MYSQL_ROOT_PASSWORD: smaily1
     volumes:
       - database:/var/lib/mysql
 volumes:

--- a/opencart 2.2.0.0/Dockerfile
+++ b/opencart 2.2.0.0/Dockerfile
@@ -27,7 +27,9 @@ RUN curl -L https://github.com/opencart/opencart/archive/$OPENCART_VERSION.tar.g
 
 # Prefill mySQL credentials
 RUN sed -i -e "s/\['db_database'] = ''/['db_database'] = 'opencart'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'examplepass'/g" install/controller/install/step_3.php \
+    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'smaily1'/g" install/controller/install/step_3.php \
+    && sed -i -e "s/\['password'] = ''/['password'] = 'smaily1'/g" install/controller/install/step_3.php \
+    && sed -i -e "s/\['email'] = ''/['email'] = 'testing@smaily.sb'/g" install/controller/install/step_3.php \
     && sed -i "s/localhost/database/g" install/controller/install/step_3.php
 
 # Add Smaily plugin files to /html

--- a/opencart 2.2.0.0/docker-compose.yml
+++ b/opencart 2.2.0.0/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: always
     environment:
       MYSQL_DATABASE: opencart
-      MYSQL_ROOT_PASSWORD: examplepass
+      MYSQL_ROOT_PASSWORD: smaily1
     volumes:
       - database:/var/lib/mysql
 volumes:

--- a/opencart 2.3.0.0 - 2.3.0.2/Dockerfile
+++ b/opencart 2.3.0.0 - 2.3.0.2/Dockerfile
@@ -28,7 +28,9 @@ RUN curl -L https://github.com/opencart/opencart/archive/$OPENCART_VERSION.tar.g
 
 # Prefill mySQL credentials
 RUN sed -i -e "s/\['db_database'] = ''/['db_database'] = 'opencart'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'examplepass'/g" install/controller/install/step_3.php \
+    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'smaily1'/g" install/controller/install/step_3.php \
+    && sed -i -e "s/\['password'] = ''/['password'] = 'smaily1'/g" install/controller/install/step_3.php \
+    && sed -i -e "s/\['email'] = ''/['email'] = 'testing@smaily.sb'/g" install/controller/install/step_3.php \
     && sed -i "s/localhost/database/g" install/controller/install/step_3.php
 
 # Add Smaily plugin files to /html

--- a/opencart 2.3.0.0 - 2.3.0.2/docker-compose.yml
+++ b/opencart 2.3.0.0 - 2.3.0.2/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: always
     environment:
       MYSQL_DATABASE: opencart
-      MYSQL_ROOT_PASSWORD: examplepass
+      MYSQL_ROOT_PASSWORD: smaily1
     volumes:
       - database:/var/lib/mysql
 volumes:

--- a/opencart 3.0.0.0 - 3.0.3.1/Dockerfile
+++ b/opencart 3.0.0.0 - 3.0.3.1/Dockerfile
@@ -28,7 +28,9 @@ RUN curl -L https://github.com/opencart/opencart/releases/download/$OPENCART_VER
 
 # Prefill mySQL credentials
 RUN sed -i -e "s/\['db_database'] = ''/['db_database'] = 'opencart'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'examplepass'/g" install/controller/install/step_3.php \
+    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'smaily1'/g" install/controller/install/step_3.php \
+    && sed -i -e "s/\['password'] = ''/['password'] = 'smaily1'/g" install/controller/install/step_3.php \
+    && sed -i -e "s/\['email'] = ''/['email'] = 'testing@smaily.sb'/g" install/controller/install/step_3.php \
     && sed -i "s/localhost/database/g" install/controller/install/step_3.php
 
 # Add Smaily plugin files to /html

--- a/opencart 3.0.0.0 - 3.0.3.1/docker-compose.yml
+++ b/opencart 3.0.0.0 - 3.0.3.1/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: always
     environment:
       MYSQL_DATABASE: opencart
-      MYSQL_ROOT_PASSWORD: examplepass
+      MYSQL_ROOT_PASSWORD: smaily1
     volumes:
       - database:/var/lib/mysql
 volumes:


### PR DESCRIPTION
Renamed `examplepass` to `smaily1` to be consistent
Added a sed script to fill out the password and e-mail inputs.
Would've used testing@smaily.sandbox instead of testing@smaily.sb but OpenCart detected it as invalid.

Tested all versions. Ready for review