### PR TITLE
Use CLI installer for OpenCart install

### DIFF
--- a/opencart 1.5.6.4/Dockerfile
+++ b/opencart 1.5.6.4/Dockerfile
@@ -6,16 +6,17 @@ ENV OPENCART_VERSION 1.5.6.4
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         tar \
-        unzip \
         libmcrypt-dev \
         libfreetype6-dev \
-        libjpeg62-turbo-dev \
         libpng-dev \
+        libjpeg62-turbo-dev \
+        mariadb-client \
     && docker-php-ext-install mcrypt \
     && docker-php-ext-install mysql \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install gd \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd
 
 # Install and extract OpenCart from GitHub.
 WORKDIR /var/www/html
@@ -23,14 +24,6 @@ RUN curl -L https://github.com/opencart/opencart/archive/$OPENCART_VERSION.tar.g
     && tar xf opencart.tar.gz \
     && mv opencart-$OPENCART_VERSION/upload/* . \
     && rm -rf opencart.tar.gz opencart-$OPENCART_VERSION/
-
-# Prefill mySQL credentials & OpenCart password and email.
-RUN sed -i -e "s/\['db_name'] = ''/['db_name'] = 'opencart'/g" install/controller/step_3.php \
-    && sed -i -e "s/\['db_user'] = ''/['db_user'] = 'root'/g" install/controller/step_3.php \
-    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'smailydev1'/g" install/controller/step_3.php \
-    && sed -i -e "s/\['password'] = ''/['password'] = 'smailydev1'/g" install/controller/step_3.php \
-    && sed -i -e "s/\['email'] = ''/['email'] = 'testing@smaily.sb'/g" install/controller/step_3.php \
-    && sed -i "s/localhost/database/g" install/controller/step_3.php
 
 RUN mv config-dist.php config.php \
     && mv admin/config-dist.php admin/config.php
@@ -44,10 +37,10 @@ RUN curl -SL https://raw.githubusercontent.com/colinmollenhour/modman/master/mod
     && chmod +x ./modman \
     && mv ./modman /usr/local/bin/
 
-# Add modman wrapper for symlinking Smaily plugin files
-ADD modman-wrapper.sh /modman-wrapper.sh
-RUN chmod +x /modman-wrapper.sh
-ENTRYPOINT ["/modman-wrapper.sh"]
+# Entrypoint for symlinking Smaily plugin files & OpenCart CLI install
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["apache2-foreground"]
 EXPOSE 80 3306

--- a/opencart 1.5.6.4/Dockerfile
+++ b/opencart 1.5.6.4/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libfreetype6-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
+        # MariaDB for mysqladmin ping in entrypoint
         mariadb-client \
     && docker-php-ext-install mcrypt \
     && docker-php-ext-install mysql \

--- a/opencart 1.5.6.4/docker-compose.yml
+++ b/opencart 1.5.6.4/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 8080:80
     environment:
-      MAGE_ROOT_DIR: /var/www/html
+      OC_ROOT_DIR: /var/www/html
     volumes:
       - app:/var/www/html
       - ./upload:/var/www/html/smailyfiles

--- a/opencart 1.5.6.4/entrypoint.sh
+++ b/opencart 1.5.6.4/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+mysql_ready() {
+    mysqladmin ping --host=database --user=root --password=smailydev1 > /dev/null 2>&1
+}
+if [ -d install ] ; then
+    while !(mysql_ready)
+    do
+        sleep 1
+        echo "Waiting for MySQL to finish..."
+    done
+    cd install/
+    # OC 1.5 cli_install.php defaults to mysql even when using --db_driver
+    sed -i -e 's/\x27mysql\\/\x27mysqli\\/g' cli_install.php
+    # Install OpenCart through the CLI installer.
+    php cli_install.php install --db_host database \
+        --db_user root \
+        --db_password smailydev1 \
+        --db_name opencart \
+        --db_port 3306 \
+        --username admin \
+        --password smailydev1 \
+        --email testing@smaily.sb \
+        --agree_tnc yes \
+        --http_server http://127.0.0.1:8080/
+    rm -rd ../install/
+fi
+echo 'OpenCart installed!'
+
+if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
+    cd $MAGE_ROOT_DIR && modman init
+fi
+# Symlink Smaily's module files to html/
+modman link /var/www/html/smailyfiles
+docker-php-entrypoint "$@"

--- a/opencart 1.5.6.4/entrypoint.sh
+++ b/opencart 1.5.6.4/entrypoint.sh
@@ -26,8 +26,8 @@ if [ -d install ] ; then
 fi
 echo 'OpenCart installed!'
 
-if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
-    cd $MAGE_ROOT_DIR && modman init
+if [ ! -d $OC_ROOT_DIR/.modman ] ; then
+    cd $OC_ROOT_DIR && modman init
 fi
 # Symlink Smaily's module files to html/
 modman link /var/www/html/smailyfiles

--- a/opencart 1.5.6.4/modman-wrapper.sh
+++ b/opencart 1.5.6.4/modman-wrapper.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -x
-
-if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
-    cd $MAGE_ROOT_DIR && modman init
-fi
-modman link /var/www/html/smailyfiles
-docker-php-entrypoint "$@"

--- a/opencart 2.2.0.0/Dockerfile
+++ b/opencart 2.2.0.0/Dockerfile
@@ -11,12 +11,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libzip-dev \
         libfreetype6-dev \
         libpng-dev \
-        libjpeg-dev \
+        libjpeg62-turbo-dev \
+        mariadb-client \
     && docker-php-ext-install mcrypt \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install zip \
     && docker-php-ext-install gd \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd
 
 # Install and extract OpenCart from GitHub to /html
 WORKDIR /var/www/html
@@ -24,13 +26,6 @@ RUN curl -L https://github.com/opencart/opencart/archive/$OPENCART_VERSION.tar.g
     && tar xf opencart.tar.gz \
     && mv opencart-$OPENCART_VERSION/upload/* . \
     && rm -rf opencart.tar.gz opencart-$OPENCART_VERSION/
-
-# Prefill mySQL credentials
-RUN sed -i -e "s/\['db_database'] = ''/['db_database'] = 'opencart'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'smailydev1'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['password'] = ''/['password'] = 'smailydev1'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['email'] = ''/['email'] = 'testing@smaily.sb'/g" install/controller/install/step_3.php \
-    && sed -i "s/localhost/database/g" install/controller/install/step_3.php
 
 RUN mv config-dist.php config.php \
     && mv admin/config-dist.php admin/config.php
@@ -44,10 +39,10 @@ RUN curl -SL https://raw.githubusercontent.com/colinmollenhour/modman/master/mod
     && chmod +x ./modman \
     && mv ./modman /usr/local/bin/
 
-# Add modman wrapper for symlinking Smaily plugin files
-ADD modman-wrapper.sh /modman-wrapper.sh
-RUN chmod +x /modman-wrapper.sh
-ENTRYPOINT ["/modman-wrapper.sh"]
+# Entrypoint for symlinking Smaily plugin files & OpenCart CLI install
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["apache2-foreground"]
 EXPOSE 80 3306

--- a/opencart 2.2.0.0/Dockerfile
+++ b/opencart 2.2.0.0/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libfreetype6-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
+        # MariaDB for mysqladmin ping in entrypoint
         mariadb-client \
     && docker-php-ext-install mcrypt \
     && docker-php-ext-install mysqli \

--- a/opencart 2.2.0.0/docker-compose.yml
+++ b/opencart 2.2.0.0/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 8080:80
     environment:
-      MAGE_ROOT_DIR: /var/www/html
+      OC_ROOT_DIR: /var/www/html
     volumes:
       - app:/var/www/html
       - ./upload:/var/www/html/smailyfiles

--- a/opencart 2.2.0.0/entrypoint.sh
+++ b/opencart 2.2.0.0/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+mysql_ready() {
+    mysqladmin ping --host=database --user=root --password=smailydev1 > /dev/null 2>&1
+}
+if [ -d install ] ; then
+    while !(mysql_ready)
+    do
+        sleep 1
+        echo "Waiting for MySQL to finish..."
+    done
+    cd install/
+    # Install OpenCart through the CLI installer.
+    php cli_install.php install --db_hostname database \
+        --db_username root \
+        --db_password smailydev1 \
+        --db_database opencart \
+        --db_driver mysqli \
+        --db_port 3306 \
+        --username admin \
+        --password smailydev1 \
+        --email testing@smaily.sb \
+        --agree_tnc yes \
+        --http_server http://127.0.0.1:8080/
+    rm -rd ../install/
+fi
+echo 'OpenCart installed!'
+
+if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
+    cd $MAGE_ROOT_DIR && modman init
+fi
+# Symlink Smaily's module files to html/
+modman link /var/www/html/smailyfiles
+docker-php-entrypoint "$@"

--- a/opencart 2.2.0.0/entrypoint.sh
+++ b/opencart 2.2.0.0/entrypoint.sh
@@ -25,8 +25,8 @@ if [ -d install ] ; then
 fi
 echo 'OpenCart installed!'
 
-if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
-    cd $MAGE_ROOT_DIR && modman init
+if [ ! -d $OC_ROOT_DIR/.modman ] ; then
+    cd $OC_ROOT_DIR && modman init
 fi
 # Symlink Smaily's module files to html/
 modman link /var/www/html/smailyfiles

--- a/opencart 2.2.0.0/modman-wrapper.sh
+++ b/opencart 2.2.0.0/modman-wrapper.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -x
-
-if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
-    cd $MAGE_ROOT_DIR && modman init
-fi
-modman link /var/www/html/smailyfiles
-docker-php-entrypoint "$@"

--- a/opencart 2.3.0.0 - 2.3.0.2/Dockerfile
+++ b/opencart 2.3.0.0 - 2.3.0.2/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libfreetype6-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
+        # MariaDB for mysqladmin ping in entrypoint
         mariadb-client \
     && pecl install mcrypt-1.0.3 \
     && docker-php-ext-enable mcrypt \

--- a/opencart 2.3.0.0 - 2.3.0.2/Dockerfile
+++ b/opencart 2.3.0.0 - 2.3.0.2/Dockerfile
@@ -11,13 +11,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libzip-dev \
         libfreetype6-dev \
         libpng-dev \
-        libjpeg-dev \
+        libjpeg62-turbo-dev \
+        mariadb-client \
     && pecl install mcrypt-1.0.3 \
     && docker-php-ext-enable mcrypt \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install zip \
     && docker-php-ext-install gd \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd
 
 # Install and extract OpenCart from GitHub to /html
 WORKDIR /var/www/html
@@ -25,13 +27,6 @@ RUN curl -L https://github.com/opencart/opencart/archive/$OPENCART_VERSION.tar.g
     && tar xf opencart.tar.gz \
     && mv opencart-$OPENCART_VERSION/upload/* . \
     && rm -rf opencart.tar.gz opencart-$OPENCART_VERSION/
-
-# Prefill mySQL credentials
-RUN sed -i -e "s/\['db_database'] = ''/['db_database'] = 'opencart'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'smailydev1'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['password'] = ''/['password'] = 'smailydev1'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['email'] = ''/['email'] = 'testing@smaily.sb'/g" install/controller/install/step_3.php \
-    && sed -i "s/localhost/database/g" install/controller/install/step_3.php
 
 RUN mv config-dist.php config.php \
     && mv admin/config-dist.php admin/config.php
@@ -45,10 +40,10 @@ RUN curl -SL https://raw.githubusercontent.com/colinmollenhour/modman/master/mod
     && chmod +x ./modman \
     && mv ./modman /usr/local/bin/
 
-# Add modman wrapper for symlinking Smaily plugin files
-ADD modman-wrapper.sh /modman-wrapper.sh
-RUN chmod +x /modman-wrapper.sh
-ENTRYPOINT ["/modman-wrapper.sh"]
+# Entrypoint for symlinking Smaily plugin files & OpenCart CLI install
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["apache2-foreground"]
 EXPOSE 80 3306

--- a/opencart 2.3.0.0 - 2.3.0.2/docker-compose.yml
+++ b/opencart 2.3.0.0 - 2.3.0.2/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 8080:80
     environment:
-      MAGE_ROOT_DIR: /var/www/html
+      OC_ROOT_DIR: /var/www/html
     volumes:
       - app:/var/www/html
       - ./upload:/var/www/html/smailyfiles

--- a/opencart 2.3.0.0 - 2.3.0.2/entrypoint.sh
+++ b/opencart 2.3.0.0 - 2.3.0.2/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+mysql_ready() {
+    mysqladmin ping --host=database --user=root --password=smailydev1 > /dev/null 2>&1
+}
+if [ -d install ] ; then
+    while !(mysql_ready)
+    do
+        sleep 1
+        echo "Waiting for MySQL to finish..."
+    done
+    cd install/
+    # Install OpenCart through the CLI installer.
+    php cli_install.php install --db_hostname database \
+        --db_username root \
+        --db_password smailydev1 \
+        --db_database opencart \
+        --db_driver mysqli \
+        --db_port 3306 \
+        --username admin \
+        --password smailydev1 \
+        --email testing@smaily.sb \
+        --agree_tnc yes \
+        --http_server http://127.0.0.1:8080/
+    rm -rd ../install/
+fi
+echo 'OpenCart installed!'
+
+if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
+    cd $MAGE_ROOT_DIR && modman init
+fi
+# Symlink Smaily's module files to html/
+modman link /var/www/html/smailyfiles
+docker-php-entrypoint "$@"

--- a/opencart 2.3.0.0 - 2.3.0.2/entrypoint.sh
+++ b/opencart 2.3.0.0 - 2.3.0.2/entrypoint.sh
@@ -25,8 +25,8 @@ if [ -d install ] ; then
 fi
 echo 'OpenCart installed!'
 
-if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
-    cd $MAGE_ROOT_DIR && modman init
+if [ ! -d $OC_ROOT_DIR/.modman ] ; then
+    cd $OC_ROOT_DIR && modman init
 fi
 # Symlink Smaily's module files to html/
 modman link /var/www/html/smailyfiles

--- a/opencart 2.3.0.0 - 2.3.0.2/modman-wrapper.sh
+++ b/opencart 2.3.0.0 - 2.3.0.2/modman-wrapper.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -x
-
-if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
-    cd $MAGE_ROOT_DIR && modman init
-fi
-modman link /var/www/html/smailyfiles
-docker-php-entrypoint "$@"

--- a/opencart 3.0.0.0 - 3.0.3.1/Dockerfile
+++ b/opencart 3.0.0.0 - 3.0.3.1/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libfreetype6-dev \
         libpng-dev \
         libjpeg62-turbo-dev \
+        # MariaDB for mysqladmin ping in entrypoint
         mariadb-client \
     && pecl install mcrypt-1.0.3 \
     && docker-php-ext-enable mcrypt \

--- a/opencart 3.0.0.0 - 3.0.3.1/Dockerfile
+++ b/opencart 3.0.0.0 - 3.0.3.1/Dockerfile
@@ -11,13 +11,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libzip-dev \
         libfreetype6-dev \
         libpng-dev \
-        libjpeg-dev \
+        libjpeg62-turbo-dev \
+        mariadb-client \
     && pecl install mcrypt-1.0.3 \
     && docker-php-ext-enable mcrypt \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install zip \
     && docker-php-ext-install gd \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
+    && docker-php-ext-install -j$(nproc) gd
 
 # Install and extract OpenCart from GitHub to /html
 WORKDIR /var/www/html
@@ -25,13 +27,6 @@ RUN curl -L https://github.com/opencart/opencart/releases/download/$OPENCART_VER
     && unzip opencart.zip -d opencart \
     && mv opencart/upload/* . \
     && rm -rf opencart.zip opencart
-
-# Prefill mySQL credentials
-RUN sed -i -e "s/\['db_database'] = ''/['db_database'] = 'opencart'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['db_password'] = ''/['db_password'] = 'smailydev1'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['password'] = ''/['password'] = 'smailydev1'/g" install/controller/install/step_3.php \
-    && sed -i -e "s/\['email'] = ''/['email'] = 'testing@smaily.sb'/g" install/controller/install/step_3.php \
-    && sed -i "s/localhost/database/g" install/controller/install/step_3.php
 
 RUN mv config-dist.php config.php \
     && mv admin/config-dist.php admin/config.php
@@ -45,10 +40,10 @@ RUN curl -SL https://raw.githubusercontent.com/colinmollenhour/modman/master/mod
     && chmod +x ./modman \
     && mv ./modman /usr/local/bin/
 
-# Add modman wrapper for symlinking Smaily plugin files
-ADD modman-wrapper.sh /modman-wrapper.sh
-RUN chmod +x /modman-wrapper.sh
-ENTRYPOINT ["/modman-wrapper.sh"]
+# Entrypoint for symlinking Smaily plugin files & OpenCart CLI install
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["apache2-foreground"]
 EXPOSE 80 3306

--- a/opencart 3.0.0.0 - 3.0.3.1/docker-compose.yml
+++ b/opencart 3.0.0.0 - 3.0.3.1/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 8080:80
     environment:
-      MAGE_ROOT_DIR: /var/www/html
+      OC_ROOT_DIR: /var/www/html
     volumes:
       - app:/var/www/html
       - ./upload:/var/www/html/smailyfiles

--- a/opencart 3.0.0.0 - 3.0.3.1/entrypoint.sh
+++ b/opencart 3.0.0.0 - 3.0.3.1/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+mysql_ready() {
+    mysqladmin ping --host=database --user=root --password=smailydev1 > /dev/null 2>&1
+}
+if [ -d install ] ; then
+    while !(mysql_ready)
+    do
+        sleep 1
+        echo "Waiting for MySQL to finish..."
+    done
+    cd install/
+    # Install OpenCart through the CLI installer.
+    php cli_install.php install --db_hostname database \
+        --db_username root \
+        --db_password smailydev1 \
+        --db_database opencart \
+        --db_driver mysqli \
+        --db_port 3306 \
+        --username admin \
+        --password smailydev1 \
+        --email testing@smaily.sb \
+        --agree_tnc yes \
+        --http_server http://127.0.0.1:8080/
+    rm -rd ../install/
+fi
+echo 'OpenCart installed!'
+
+if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
+    cd $MAGE_ROOT_DIR && modman init
+fi
+# Symlink Smaily's module files to html/
+modman link /var/www/html/smailyfiles
+docker-php-entrypoint "$@"

--- a/opencart 3.0.0.0 - 3.0.3.1/entrypoint.sh
+++ b/opencart 3.0.0.0 - 3.0.3.1/entrypoint.sh
@@ -25,8 +25,8 @@ if [ -d install ] ; then
 fi
 echo 'OpenCart installed!'
 
-if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
-    cd $MAGE_ROOT_DIR && modman init
+if [ ! -d $OC_ROOT_DIR/.modman ] ; then
+    cd $OC_ROOT_DIR && modman init
 fi
 # Symlink Smaily's module files to html/
 modman link /var/www/html/smailyfiles

--- a/opencart 3.0.0.0 - 3.0.3.1/modman-wrapper.sh
+++ b/opencart 3.0.0.0 - 3.0.3.1/modman-wrapper.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -x
-
-if [ ! -d $MAGE_ROOT_DIR/.modman ] ; then
-    cd $MAGE_ROOT_DIR && modman init
-fi
-modman link /var/www/html/smailyfiles
-docker-php-entrypoint "$@"


### PR DESCRIPTION
Replace data prefilling with sed in favor of the CLI installer.
Still needs work on 1.5.6.4