### PR TITLE
Add workflow to generate a zip file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+name: Create a ZIP version 2.2.x
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  compress:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: 2.2.x
+
+      - name: Get plugin version from tag
+        id: version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/*/} # Gets tag name from release.
+
+      - name: Compress ZIP
+        uses: TheDoctor0/zip-release@v0.3.0
+        with:
+          filename: release.zip
+          exclusions: "*.git* /*.sandbox/* /*assets/* upload/modman docker-compose.yaml Dockerfile"
+
+      - name: Get release
+        id: get_release_url
+        uses: bruceadams/get-release@v1.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release_url.outputs.upload_url }}
+          asset_path: ./release.zip
+          asset_name: smailyforopencart-${{ steps.version.outputs.version }}.ocmod.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Workflow builds a zip file and adds it to a release.

Release tags should be formatted as `2.2.x-1.2.0`.