### PR TITLE
Fix customer cron sync time not being updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.2.1
+
+- Fixes last customer synchronization time not being updated
+
 ### 1.2.0
 
 **Breaking change**
@@ -12,7 +16,6 @@ For further updates to work please uninstall older version and reinstall this mo
 - Add `product_base_price` field. Product `price` and `base_price` fields now pass prices with currency symbol.
 - Add `product_sku` field.
 - Fix bug where running customer synchronization throws PHP error.
-
 
 ### 1.1.4
 

--- a/install.xml
+++ b/install.xml
@@ -2,7 +2,7 @@
 <modification>
     <code>smaily_for_opencart_extension</code>
     <name>Smaily for OpenCart</name>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <author>Smaily</author>
     <link>https://github.com/sendsmaily/smaily-opencart-module</link>
 </modification>

--- a/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -11,7 +11,7 @@
  *
  * Plugin Name: Smaily for OpenCart
  * Description: Smaily email marketing and automation extension plugin for OpenCart.
- * Version: 1.2.0
+ * Version: 1.2.1
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -54,6 +54,13 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
             if ($validated) {
                 $data['module_smaily_for_opencart_validated'] = $validated;
             }
+            // Add sync time.
+            $sync_time = $this->model_setting_setting->getSettingValue('module_smaily_for_opencart_sync_time');
+            // Init value before sync.
+            if (!isset($sync_time)) {
+                $sync_time = date('c', 0);
+            }
+            $data['module_smaily_for_opencart_sync_time'] = $sync_time;
             // Get credentials.
             $data['module_smaily_for_opencart_subdomain'] = $this->model_setting_setting->getSettingValue(
                 'module_smaily_for_opencart_subdomain'

--- a/upload/catalog/model/extension/smailyforopencart/helper.php
+++ b/upload/catalog/model/extension/smailyforopencart/helper.php
@@ -204,14 +204,18 @@ class ModelExtensionSmailyForOpencartHelper extends Model {
     }
 
     /**
-     * Get ISO sync time from settings and convert it to MySQL format.
+     * Get UTC sync time from settings.
      *
      * @return string $sync_time Time of last sync
      */
     public function getSyncTime() {
         $this->load->model('setting/setting');
-        $sync_time = $this->model_setting_setting->getSettingValue('module_smaily_for_opencart_sync_time') ?: date('c', 0);
-        return date("Y-m-d H:i:s", strtotime($sync_time));
+        $sync_time = $this->model_setting_setting->getSettingValue('module_smaily_for_opencart_sync_time');
+        if (!isset($sync_time)) {
+            return date('c', 0); #Failsafe for first sync.
+        }
+
+        return $sync_time;
     }
 
     public function editSettingValue($code = '', $key = '', $value = '', $store_id = 0) {


### PR DESCRIPTION
Customer cron `sync_time` is now initialized when saving settings on the admin page. Also, previous `sync_time` is not discarded when saving settings on the admin page.
Fixes #57 