### PR TITLE
Fix valid credentials not accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.3.1
+
+- Fix valid credentials not accepted when validating connection with Smaily
+
 ### 1.3.0
 
 - Enable module on successful credentials validation

--- a/install.xml
+++ b/install.xml
@@ -2,7 +2,7 @@
 <modification>
     <code>smaily_for_opencart_extension</code>
     <name>Smaily for OpenCart</name>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <author>Smaily</author>
     <link>https://github.com/sendsmaily/smaily-opencart-module</link>
 </modification>

--- a/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -487,10 +487,9 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
                 $subdomain = $parts[0];
             }
             $subdomain = preg_replace('/[^a-zA-Z0-9]+/', '', $subdomain);
+            $username = html_entity_decode($this->request->post['username']);
+            $password = html_entity_decode($this->request->post['password']);
 
-            $subdomain = $this->db->escape($subdomain);
-            $username =  $this->db->escape($this->request->post['username']);
-            $password = $this->db->escape($this->request->post['password']);
             // Validate credentials with a call to Smaily.
             $validate = $this->validateSmailyCredentials($subdomain, $username, $password);
 
@@ -503,9 +502,9 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
                     $settings['module_smaily_for_opencart_status'] = 1;
                     // Used because save button saves whole form.
                     $settings['module_smaily_for_opencart_validated'] = 1;
-                    $settings['module_smaily_for_opencart_subdomain'] = $subdomain;
-                    $settings['module_smaily_for_opencart_username'] = $username;
-                    $settings['module_smaily_for_opencart_password'] = $password;
+                    $settings['module_smaily_for_opencart_subdomain'] = $this->db->escape($subdomain);
+                    $settings['module_smaily_for_opencart_username'] = $this->db->escape($username);
+                    $settings['module_smaily_for_opencart_password'] = $this->db->escape($password);
                     // Save credentials to db.
                     $this->model_setting_setting->editSetting('module_smaily_for_opencart', $settings);
                     $response['success'] = $validate['success'];

--- a/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -11,7 +11,7 @@
  *
  * Plugin Name: Smaily for OpenCart
  * Description: Smaily email marketing and automation extension plugin for OpenCart.
- * Version: 1.3.0
+ * Version: 1.3.1
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/


### PR DESCRIPTION
Fixes #61 

Currently, credentials posted that were URL escaped didn't get encoded and caused validation to fail. This pull-request fixes this issue by first decoding posted fields and then validating with decoded values.