### PR TITLE
Bump OC versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.3-apache
 
-ENV OPENCART_VERSION 3.0.3.1
+ENV OPENCART_VERSION 3.0.3.6
 
 # Install packages required for OpenCart.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Automatically synchronize subscribed customers to Smaily, generate RSS-feed base
 
 ## Requirements
 
-- PHP 7.3
 - OpenCart 3.0.0.0 to 3.0.3.6
 
 ## Documentation & Support

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Automatically synchronize subscribed customers to Smaily, generate RSS-feed base
 ## Requirements
 
 - PHP 5.6 (PHP 7.2+ is recommended)
-- OpenCart 3.0.0.0 to 3.0.3.1
+- OpenCart 3.0.0.0 to 3.0.3.6
 
 ## Documentation & Support
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Automatically synchronize subscribed customers to Smaily, generate RSS-feed base
 
 ## Requirements
 
-- PHP 5.6 (PHP 7.2+ is recommended)
+- PHP 7.3
 - OpenCart 3.0.0.0 to 3.0.3.6
 
 ## Documentation & Support


### PR DESCRIPTION
Tested out newer versions (3.0.3.1+) and found no issues with our plugin. Releases mainly dealt with adding/removing extensions.
Although newer OpenCart versions (since 3.0.3.5) now require PHP 7.3 as a minimum, added it to README
for #110