### PR TITLE
Display module version

### DIFF
--- a/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -31,6 +31,7 @@
  */
 class ControllerExtensionModuleSmailyForOpencart extends Controller {
     private $error = array();
+    private $version = '1.4.0';
 
     public function index() {
         // Add language file.
@@ -141,7 +142,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
             }
         }
         // Text fields
-        $data['heading_title'] = $this->language->get('heading_title');
+        $data['heading_title'] = $this->language->get('heading_title') . " v" . $this->version;
         $data['text_edit']     = $this->language->get('text_edit');
         $data['text_enabled']  = $this->language->get('text_enabled');
         $data['text_disabled'] = $this->language->get('text_disabled');


### PR DESCRIPTION
for #125

tried getting plugin version from install.xml but realized that file can't be accessed if plugin was manually installed.
searched the sql database and the plugin version isn't stored anywhere, no chance querying it from some table.
created a variable and appended it to the heading title, this has to be updated as new versions are released.