### PR TITLE
Fix mistakes introduced by refactoring to Request class

### DIFF
--- a/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
+++ b/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
@@ -104,7 +104,7 @@ class ControllerExtensionSmailyForOpencartCronCustomers extends Controller {
                 (new \SmailyForOpenCart\Request)
                     ->setSubdomain($subdomain)
                     ->setCredentials($username, $password)
-                    ->post('contact', $subscribers);
+                    ->post('contact', $list);
             } catch (SmailyForOpenCart\HTTPError $error) {
                 $msg = $error->getMessage();
                 $this->log->write($msg);

--- a/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
+++ b/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
@@ -67,7 +67,8 @@ class ControllerExtensionSmailyForOpencartCronCustomers extends Controller {
             foreach ($unsubscribers as $unsubscriber) {
                 array_push($unsubscribers_emails, $unsubscriber['email']);
             }
-
+            // unsubscribeCustomers method would compile a single update query.
+            $this->model_extension_smailyforopencart_helper->unsubscribeCustomers($unsubscribers_emails);
             $offset_unsub += 1;
         }
 

--- a/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
+++ b/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
@@ -67,6 +67,7 @@ class ControllerExtensionSmailyForOpencartCronCustomers extends Controller {
             foreach ($unsubscribers as $unsubscriber) {
                 array_push($unsubscribers_emails, $unsubscriber['email']);
             }
+
             // unsubscribeCustomers method would compile a single update query.
             $this->model_extension_smailyforopencart_helper->unsubscribeCustomers($unsubscribers_emails);
             $offset_unsub += 1;

--- a/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
+++ b/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
@@ -101,7 +101,7 @@ class ControllerExtensionSmailyForOpencartCronCustomers extends Controller {
             }
             // Send subscribers to smaily.
             try {
-                (new \SmailyForOpenCart\Request)
+                $response = (new \SmailyForOpenCart\Request)
                     ->setSubdomain($subdomain)
                     ->setCredentials($username, $password)
                     ->post('contact', $list);


### PR DESCRIPTION
Things I noticed developing 2.3.x

- Instead of using $list, $subscirbers array is sent towards Smaily API endpoint. This sends all fields attributed to the customer in a request. We should only send fields the customer has enabled in settings. 
 
- unsubscribeCustomers() function was deleted, which forgoes setting newsletter to '0' in local store DB
 
- $response variable was deleted in try/catch block. This leaves only one declaration of $response, "no customers to sync". Which is then printed to the log after running customer sync.