### PR TITLE
Use error handling for requests like used in 1.5.x

### DIFF
--- a/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -692,7 +692,7 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
                 ->setCredentials($username, $password)
                 ->get('workflows', array('trigger_type' => 'form_submitted'));
         } catch (SmailyForOpenCart\HTTPError $error) {
-            $this->log->write($error->getMessage());
+            $this->log->write($error);
         }
 
         if (empty($autoresponders)) {

--- a/upload/catalog/controller/extension/smailyforopencart/cron_cart.php
+++ b/upload/catalog/controller/extension/smailyforopencart/cron_cart.php
@@ -139,18 +139,14 @@ class ControllerExtensionSmailyForOpencartCronCart extends Controller {
                     ->post('autoresponder', $query);
             // cURL failed.
             } catch (SmailyForOpenCart\HTTPError $error) {
-                $msg = $error->getMessage();
-                $this->log->write($msg);
-                echo($msg);
-                die(1);
+                $this->log->write($error);
+                die($error);
             // cURL successful but response code from Smaily hints to error.
             } catch (SmailyForOpenCart\APIError $error) {
-                $msg = $error->getMessage();
-                $this->log->write($msg);
+                $this->log->write($error);
                 // Save invalid email to database as sent because we do not want to repeatedly retry sending.
                 if ($error->getCode() !== SmailyForOpenCart\Request::API_ERR_INVALID_DATA) {
-                    echo($msg);
-                    die(1);
+                    die($error);
                 }
             }
             // If successful response or email invalid: add customer to table and don't retry sending.

--- a/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
+++ b/upload/catalog/controller/extension/smailyforopencart/cron_customers.php
@@ -47,15 +47,11 @@ class ControllerExtensionSmailyForOpencartCronCustomers extends Controller {
                     ->setCredentials($username, $password)
                     ->get('contact', $query);
             } catch (SmailyForOpenCart\HTTPError $error) {
-                $msg = $error->getMessage();
-                $this->log->write($msg);
-                echo($msg);
-                die(1);
+                $this->log->write($error);
+                die($error);
             } catch (SmailyForOpenCart\APIError $error) {
-                $msg = $error->getMessage();
-                $this->log->write($msg);
-                echo($msg);
-                die(1);
+                $this->log->write($error);
+                die($error);
             }
 
             // Exit while loop if api returns no unsubscribers.
@@ -107,18 +103,14 @@ class ControllerExtensionSmailyForOpencartCronCustomers extends Controller {
                     ->setCredentials($username, $password)
                     ->post('contact', $list);
             } catch (SmailyForOpenCart\HTTPError $error) {
-                $msg = $error->getMessage();
-                $this->log->write($msg);
-                echo($msg);
-                die(1);
+                $this->log->write($error);
+                die($error);
             } catch (SmailyForOpenCart\APIError $error) {
-                $msg = $error->getMessage();
-                $this->log->write($msg);
+                $this->log->write($error);
                 // Stop code execution and display error unless an invalid email was in query.
                 // Smaily subscribes all valid emails and discards the rest.
                 if ($error->getCode() !== SmailyForOpenCart\Request::API_ERR_INVALID_DATA) {
-                    echo($msg);
-                    die(1);
+                    die($error);
                 }
             }
         }


### PR DESCRIPTION
this
```
} catch (SmailyError $error) {
  $msg = $error->getMessage();
  $this->log->write($msg);
  echo($msg);
```
prints out _GET/POST request to Smaily API_ but should print _Smaily API Error: %s. API code: %d;_
