### PR TITLE
Fix unsubscribing in chunks not working in chunks

### DIFF
--- a/upload/catalog/model/smailyforopencart/helper.php
+++ b/upload/catalog/model/smailyforopencart/helper.php
@@ -45,7 +45,7 @@ class ModelSmailyForOpencartHelper extends Model {
         $chunks = array_chunk($emails, 500);
         foreach ($chunks as $chunk) {
             $binds = array();
-            foreach ($emails as $email) {
+            foreach ($chunk as $email) {
                 $binds[] = $this->db->escape($email);
             }
             // Add all emails to long string seperated by commas.


### PR DESCRIPTION
it would load all customers emails into an array and then unsubscribe them x amount of times, x being the length of customers email divided by chunk limit (500), i.e 2000 emails/500 limiter runs an SQL query to unsubscribe 2000 customers from DB four times repeatedly.

