### PR TITLE
Include abandoned cart page documentation in 1.5.0 for for 2.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 1.5.0
 
+- Add admin page for managing abandoned carts - [[#65](https://github.com/sendsmaily/smaily-opencart-module/issues/65)
 - Fix abandoned cart CRON getting stuck - [[#124](https://github.com/sendsmaily/smaily-opencart-module/issues/124)]
 - Display module version in admin area - [[#125](https://github.com/sendsmaily/smaily-opencart-module/issues/125)]
 - Fix RSS product limit value error popping up when saving for first time - [[#138](https://github.com/sendsmaily/smaily-opencart-module/issues/138)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,19 @@ You need to provide a **token** as a parameter for security reasons so that only
 
 We recommend to run Customer Synchronization daily and Abandoned Carts not more often than every hour.
 
+## Using Module to View Status of Abandoned Carts
+
+To view the status of sent and pending abandoned carts you must open up the **Abandoned Cart Status** tab under module settings.
+
+The section will be populated by unsent abandoned carts, this happens automatically when a registered customer adds items to their shopping cart. The cart will be considered abandoned when items have been sitting in the shopping cart longer than the configured **Abandoned cart delay time** and during which the customer has not finalized their order. If you have enabled Abandoned Cart in module settings and when the cart has been considered abandoned, an automated abandoned cart email will be sent to the customer. If an abandoned cart email has been successfully sent, the cart will be marked as SENT and the Date & Time of email will be saved to the table. The shopping cart contents of sent abandoned cart emails will not be saved to the table.
+
+
 ## Frequently Asked Questions
+
+### How do I sort abandoned carts in the Abandoned Cart Status table?
+
+Abandoned carts in the table can be sorted by: customer name, customer e-mail, email date & time and status under **Abandoned Cart Status** tab.
+Sorting can be accomplished by clicking on the table headers of the same name (i.e status) marked blue. Clicking twice on them will change the order of sorting, to ascending or descending.
 
 ### How can I filter RSS-feed output by category and limit results?
 


### PR DESCRIPTION
Abandoned cart page was merged into 1.5.0 some time ago, forgot to write about it for the release.
Added it to changelog and wrote a readme section for it