### PR TITLE
Stylesheet for abandoned carts table wasn't added

### DIFF
--- a/upload/admin/view/stylesheet/abandoned_carts_table.css
+++ b/upload/admin/view/stylesheet/abandoned_carts_table.css
@@ -1,0 +1,3 @@
+.SmailyAbandonedCartsTable>tbody>tr>td {
+    vertical-align: top;
+  }

--- a/upload/admin/view/stylesheet/smaily_oc.css
+++ b/upload/admin/view/stylesheet/smaily_oc.css
@@ -1,3 +1,0 @@
-.SmailyAbandonedCartsTable>tbody>tr>td {
-    vertical-align: top;
-  }

--- a/upload/admin/view/template/module/smaily_for_opencart.tpl
+++ b/upload/admin/view/template/module/smaily_for_opencart.tpl
@@ -438,6 +438,7 @@
   </div>
 <?php echo $footer; ?>
 </div>
+<link rel="stylesheet" type="text/css" href="view/stylesheet/smaily_oc.css" />
 <script type="text/javascript">
 (function($) {
    $(window).on("load", function() {

--- a/upload/admin/view/template/module/smaily_for_opencart.tpl
+++ b/upload/admin/view/template/module/smaily_for_opencart.tpl
@@ -438,7 +438,7 @@
   </div>
 <?php echo $footer; ?>
 </div>
-<link rel="stylesheet" type="text/css" href="view/stylesheet/smaily_oc.css" />
+<link rel="stylesheet" type="text/css" href="view/stylesheet/smailyforopencart/abandoned_carts_table.css " />
 <script type="text/javascript">
 (function($) {
    $(window).on("load", function() {

--- a/upload/modman
+++ b/upload/modman
@@ -3,7 +3,7 @@ admin/controller/smailyforopencart/upgrade.php                     admin/control
 admin/language/en-gb/module/smaily_for_opencart.php                admin/language/en-gb/module/smaily_for_opencart.php
 admin/model/smailyforopencart/admin.php                            admin/model/smailyforopencart/admin.php
 admin/view/template/module/smaily_for_opencart.tpl                 admin/view/template/module/smaily_for_opencart.tpl
-admin/view/stylesheet/smaily_oc.css                                admin/view/stylesheet/smaily_oc.css
+admin/view/stylesheet/smailyforopencart/abandoned_carts_table.css  admin/view/stylesheet/smailyforopencart/abandoned_carts_table.css
 catalog/controller/module/smaily_for_opencart.php                  catalog/controller/module/smaily_for_opencart.php
 catalog/controller/smailyforopencart/cron_cart.php                 catalog/controller/smailyforopencart/cron_cart.php
 catalog/controller/smailyforopencart/cron_customers.php            catalog/controller/smailyforopencart/cron_customers.php


### PR DESCRIPTION
If the shopping cart is very big, the table contents will be directly at the center, even when table cells have been stretched wide. 
The stylesheet aligns it to the top.