### PR TITLE
Release 1.5.1 for 2.2.x cointains incorrect item in changelog.md 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### 1.5.1
 
-- Fix RSS feed not displaying product title and description correctly - [[#167](https://github.com/sendsmaily/smaily-opencart-module/issues/167)]
 - Fix RSS feed not displaying product pictures - [[#168](https://github.com/sendsmaily/smaily-opencart-module/issues/168)]
 
 ### 1.5.0


### PR DESCRIPTION
Sorry again. I wrongly remembered I added `html_entity_decode` to RSS for 2.2.x like it was in 3.0.x, but this is not correct.