### PR TITLE
Add paranthesis to if statement when checking if RSS limit is in range

### DIFF
--- a/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -572,9 +572,9 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
 
         // Validate RSS product limit value
         if (isset($this->request->post['smaily_for_opencart_rss_limit'])
-        && (int) $this->request->post['smaily_for_opencart_rss_limit'] < 1
+        &&  ((int) $this->request->post['smaily_for_opencart_rss_limit'] < 1
         || (int) $this->request->post['smaily_for_opencart_rss_limit'] > 250
-        ) {
+        )) {
             $this->error['rss_limit'] = $this->language->get('rss_limit_error');
         }
         return !$this->error;


### PR DESCRIPTION
Adding parenthesis, the expression doesn't evaluate the rest of the statement if the RSS limit is not set. Previously if the RSS limit was not set it would still evaluate the range of 1-250, prompting an undefined index error.

Fix for issue #190 