### PR TITLE
RSS product limit was using wrong index

### DIFF
--- a/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -571,9 +571,9 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
         }
 
         // Validate RSS product limit value
-        if (isset($this->request->post['smaily_for_opencart_rss_limit'])
-        &&  ((int) $this->request->post['smaily_for_opencart_rss_limit'] < 1
-        || (int) $this->request->post['smaily_for_opencart_rss_limit'] > 250
+        if (isset($this->request->post['module_smaily_for_opencart_rss_limit'])
+        &&  ((int) $this->request->post['module_smaily_for_opencart_rss_limit'] < 1
+        || (int) $this->request->post['module_smaily_for_opencart_rss_limit'] > 250
         )) {
             $this->error['rss_limit'] = $this->language->get('rss_limit_error');
         }


### PR DESCRIPTION
Input fields are prefixed with `module_` in 3.0.x but RSS product limit was not using that prefix and this resulted in an undefined index error.
Related to issue #190 