### PR TITLE
RSS product limit expression requires parentheses

### DIFF
--- a/upload/admin/controller/module/smaily_for_opencart.php
+++ b/upload/admin/controller/module/smaily_for_opencart.php
@@ -548,9 +548,9 @@ class ControllerModuleSmailyForOpencart extends Controller {
         }
         // Validate RSS product limit value
         if (isset($this->request->post['smaily_for_opencart_rss_limit'])
-        && (int) $this->request->post['smaily_for_opencart_rss_limit'] < 1
+        && ((int) $this->request->post['smaily_for_opencart_rss_limit'] < 1
         || (int) $this->request->post['smaily_for_opencart_rss_limit'] > 250
-        ) {
+        )) {
             $this->error['rss_limit'] = $this->language->get('rss_limit_error');
         }
         return !$this->error;


### PR DESCRIPTION
Previously it would only pop an error if value was below 1.