### PR TITLE
Release 1.5.2 for 2.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.5.2
+
+- Fix validation error not showing if RSS product limit higher than 250 - [[#194](https://github.com/sendsmaily/smaily-opencart-module/pull/194)]
+
 ### 1.5.1
 
 - Fix RSS feed not displaying product pictures - [[#168](https://github.com/sendsmaily/smaily-opencart-module/issues/168)]

--- a/install.xml
+++ b/install.xml
@@ -2,7 +2,7 @@
 <modification>
     <code>smaily_for_opencart_extension</code>
     <name>Smaily for OpenCart</name>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <author>Smaily</author>
     <link>https://github.com/sendsmaily/smaily-opencart-module</link>
 </modification>

--- a/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -578,11 +578,11 @@ class ControllerExtensionModuleSmailyForOpencart extends Controller {
             // Error message.
             $this->error['validate'] = $this->language->get('error_validate');
         }
-        // Validate RSS product limit value
+        // Validate RSS product limit value.
         if (isset($this->request->post['smaily_for_opencart_rss_limit'])
-            && (int) $this->request->post['smaily_for_opencart_rss_limit'] < 1
-            || (int) $this->request->post['smaily_for_opencart_rss_limit'] > 250
-            ) {
+        && ((int) $this->request->post['smaily_for_opencart_rss_limit'] < 1
+        || (int) $this->request->post['smaily_for_opencart_rss_limit'] > 250
+        )) {
             $this->error['rss_limit'] = $this->language->get('rss_limit_error');
         }
         return !$this->error;

--- a/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -11,7 +11,7 @@
  *
  * Plugin Name: Smaily for OpenCart
  * Description: Smaily email marketing and automation extension plugin for OpenCart.
- * Version: 1.5.1
+ * Version: 1.5.2
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -32,7 +32,7 @@
 require_once(DIR_SYSTEM . 'library/smailyforopencart/request.php');
 class ControllerExtensionModuleSmailyForOpencart extends Controller {
     private $error = array();
-    private $version = '1.5.1';
+    private $version = '1.5.2';
 
     public function index() {
         // Add language file.


### PR DESCRIPTION
# Plugin Version: 1.5.2

**Version changelog**

A list of changes regarding the next version release:

- Fix validation error not showing if RSS product limit higher than 250 - [[#194](https://github.com/sendsmaily/smaily-opencart-module/pull/194)]

**Release checklist**

- [X] Added `release` and appropriate platform version tag to this pull request
- [x] Updated README.md
- [x] Updated CHANGELOG.md
- [x] Updated plugin version number
- [x] Updated version displayed via controller
- [x] Updated screenshots in assets folder
- [x] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Updated plugin on the OpenCart marketplace
- [ ] Pinged code owners to inform marketing about new version
