### PR TITLE
abandoned-cart: Add new mandatory fields to request payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 1.5.4
+
+- Adds is_abandoned_cart field to request payload for better contact filtering in Smaily.
+- Stops subscribing unsubscribed customers in case of receiving abandoned cart emails.
+
 ### 1.5.3
 
 - Update user manual links - [[#217](https://github.com/sendsmaily/smaily-opencart-module/pull/217)]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,15 @@ You can run the environment by executing:
 
 > **Note!** Make sure you do not have any other process(es) listening on ports 8080 and 8888.
 
+## Accessing admin panel
+
+Username and password for the administrator account are set during the installation of OpenCart. These default credentials reside in the `.sandbox/entrypont.sh` file.
+
+- **Username:** `admin`
+- **Password:** `smailydev1`
+
+Admin panel is accessible at `localhost:8080/admin`.
+
 ## Stopping the environment
 
 Environment can be stopped by executing:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.3-apache
 
-ENV OPENCART_VERSION 3.0.3.6
+ENV OPENCART_VERSION 3.0.4.0
 
 # Install packages required for OpenCart.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Automatically synchronize subscribed customers to Smaily, generate RSS-feed base
 
 - Generate RSS-feed with 50 latest updated products for easy import to Smaily template
 - Option to customize generated RSS-feed based on products categories
-- Option to limit generated RSS-feed products amount with prefered value
+- Option to limit generated RSS-feed products amount with preferred value
 
 ### Opt-in subscription form
 
@@ -29,11 +29,11 @@ Automatically synchronize subscribed customers to Smaily, generate RSS-feed base
 
 - Automatically notify customers about their abandoned cart
 - Send abandoned cart information to smaily for easy use on templates
-- Set delay time when cart is considered abadoned
+- Set delay time when cart is considered abandoned
 
 ## Requirements
 
-- OpenCart 3.0.0.0 to 3.0.3.6
+- OpenCart 3.x
 
 ## Documentation & Support
 
@@ -77,7 +77,7 @@ Before starting the installation process, download the version of the module you
 5. Select autoresponder for customer synchronization and extra fields you would like to add. Cron token must be added for security.
 6. Select if you want to use Cron for sending abandoned cart emails.
 7. Select autoresponder for abandoned carts, extra fields you would like to add to template and delay for abandoned carts. Cron token required for security.
-8. To add subscription form to your homepage go to **Design** &rarr; **Layouts** &rarr; **Home** and add `Smaily for OpenCart` to your prefered position.
+8. To add subscription form to your homepage go to **Design** &rarr; **Layouts** &rarr; **Home** and add `Smaily for OpenCart` to your preferred position.
 9. That's it, your OpenCart store is now integrated with Smaily!
 
 ## Using Cron to Automate Customer Synchronization and Sending Abandoned Carts Emails
@@ -114,7 +114,9 @@ List of all parameters available in Smaily email templating engine:
 
 - Customer last name: `{{ last_name }}`.
 
-Up to 10 products can be received in Smaily templating engine. You can refrence each product with number 1-10 behind parameter name.
+- Is abandoned cart: `{{ is_abandoned_cart }}`.
+
+Up to 10 products can be received in Smaily templating engine. You can reference each product with number 1-10 behind parameter name.
 
 - Product name: `{{ product_name_[1-10] }}`.
 
@@ -135,7 +137,7 @@ Also you can determine if customer had more than 10 items in cart
 ## Screenshots found in /assets
 
 1. OpenCart Smaily general settings screen.
-2. OpenCart Smaily customer synchronisation settings screen.
-3. OpenCart Smaily abadoned cart settings screen.
+2. OpenCart Smaily customer synchronization settings screen.
+3. OpenCart Smaily abandoned cart settings screen.
 4. OpenCart Smaily RSS-feed screen.
 5. OpenCart Smaily form screen.

--- a/install.xml
+++ b/install.xml
@@ -2,7 +2,7 @@
 <modification>
     <code>smaily_for_opencart_extension</code>
     <name>Smaily for OpenCart</name>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
     <author>Smaily</author>
     <link>https://github.com/sendsmaily/smaily-opencart-module</link>
 </modification>

--- a/upload/admin/controller/extension/module/smaily_for_opencart.php
+++ b/upload/admin/controller/extension/module/smaily_for_opencart.php
@@ -12,7 +12,7 @@
  *
  * Plugin Name: Smaily for OpenCart
  * Description: Smaily email marketing and automation extension plugin for OpenCart.
- * Version: 1.5.3
+ * Version: 1.5.4
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -35,7 +35,7 @@ require_once DIR_SYSTEM . 'library/smailyforopencart/request.php';
 
 class ControllerExtensionModuleSmailyForOpencart extends Controller {
 	private $error = [];
-	private $version = '1.5.3';
+	private $version = '1.5.4';
 
 	public function index() {
 		// Add language file.

--- a/upload/catalog/controller/extension/smailyforopencart/cron_cart.php
+++ b/upload/catalog/controller/extension/smailyforopencart/cron_cart.php
@@ -55,6 +55,8 @@ class ControllerExtensionSmailyForOpencartCronCart extends Controller {
 			// Address array for smaily api call.
 			$address = array(
 				'email' => $cart['email'],
+				'is_abandoned_cart' => 'true',
+				'force_opt_in' => false,
 			);
 
 			// Add customer fields.


### PR DESCRIPTION
# Plugin Version : 1.5.4

**Version changelog**

A list of changes regarding the next version release:

1. Adds is_abandoned_cart field to request payload for better contact filtering in Smaily. 
2. Stops subscribing unsubscribed customers in case of receiving abandoned cart emails. 
3. Tested compatibility with the latest 3.x OpenCart version.
4.  Fix tipos in the readme file and loosen the requirement for 3.x instead of targeting the patch version.

**Release checklist**

- [x] Added `release` and appropriate platform version tag to this pull request
- [x] Updated README.md
- [x] Updated CHANGELOG.md
- [x] Updated plugin version number
- [x] Updated version displayed via controller
- [ ] Updated screenshots in assets folder
- [ ] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Updated plugin on the OpenCart marketplace
- [ ] Pinged code owners to inform marketing about new version
